### PR TITLE
[Bugfix] Fixes week range creation logic to not always use current time

### DIFF
--- a/app/src/androidTest/java/org/wspcgir/strong_giraffe/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/org/wspcgir/strong_giraffe/ExampleInstrumentedTest.kt
@@ -71,7 +71,7 @@ class ExampleInstrumentedTest() {
                 val setCounts = repo.setsForMusclesInWeek(Instant.now()).setCounts
                 val length = repo.setsForMusclesInWeek(Instant.now()).setCounts.size
                 assertEquals(1, length)
-                assertEquals(1, setCounts[muscle.id]?.second)
+                assertEquals(1, setCounts[muscle.id]?.thisWeek)
             }
         }
     }
@@ -93,7 +93,7 @@ class ExampleInstrumentedTest() {
                 val setCounts = repo.setsForMusclesInWeek(Instant.now()).setCounts
                 val length = repo.setsForMusclesInWeek(Instant.now()).setCounts.size
                 assertEquals(1, length)
-                assertEquals(2, setCounts[muscle.id]?.second)
+                assertEquals(2, setCounts[muscle.id]?.thisWeek)
             }
         }
     }
@@ -114,7 +114,7 @@ class ExampleInstrumentedTest() {
                 val setCounts = repo.setsForMusclesInWeek(Instant.now()).setCounts
                 val length = repo.setsForMusclesInWeek(Instant.now()).setCounts.size
                 assertEquals(1, length)
-                assertEquals(4, setCounts[muscle.id]?.second)
+                assertEquals(4, setCounts[muscle.id]?.thisWeek)
             }
         }
     }
@@ -142,8 +142,8 @@ class ExampleInstrumentedTest() {
                 val setCounts = repo.setsForMusclesInWeek(Instant.now()).setCounts
                 val length = repo.setsForMusclesInWeek(Instant.now()).setCounts.size
                 assertEquals(2, length)
-                assertEquals(1, setCounts[muscleA.id]?.second)
-                assertEquals(0, setCounts[muscleB.id]?.second)
+                assertEquals(1, setCounts[muscleA.id]?.thisWeek)
+                assertEquals(0, setCounts[muscleB.id]?.thisWeek)
             }
         }
     }

--- a/app/src/main/java/org/wspcgir/strong_giraffe/model/WeekRange.kt
+++ b/app/src/main/java/org/wspcgir/strong_giraffe/model/WeekRange.kt
@@ -12,8 +12,7 @@ data class WeekRange(
 
     companion object {
         fun forInstant(now: Instant, zone: TimeZone): WeekRange {
-            val tz = TimeZone.getDefault()
-            val time = OffsetDateTime.ofInstant(Instant.now(), tz.toZoneId())
+            val time = OffsetDateTime.ofInstant(now, zone.toZoneId())
             val startOfWeek = time
                 .minusDays(time.dayOfWeek.value.toLong() % 7)
                 .withHour(0)


### PR DESCRIPTION
# Summary

The function `WeekRange.forInstant` wasn't actually using it's inputs