### PR TITLE
[Bugfix] Missing muscles in list

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "org.wspcgir.strong_giraffe"
         minSdk 33
         targetSdk 34
-        versionCode 9
-        versionName "0.4.5"
+        versionCode 10
+        versionName "0.4.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/androidTest/java/org/wspcgir/strong_giraffe/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/org/wspcgir/strong_giraffe/ExampleInstrumentedTest.kt
@@ -12,9 +12,12 @@ import org.junit.runner.RunWith
 
 import org.junit.Assert.*
 import org.wspcgir.strong_giraffe.model.Intensity
+import org.wspcgir.strong_giraffe.model.WeekRange
 import org.wspcgir.strong_giraffe.repository.AppDatabase
 import org.wspcgir.strong_giraffe.repository.AppRepository
 import java.time.Instant
+import java.time.OffsetDateTime
+import java.util.TimeZone
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -140,10 +143,40 @@ class ExampleInstrumentedTest() {
                 assertEquals(2, muscles.size)
 
                 val setCounts = repo.setsForMusclesInWeek(Instant.now()).setCounts
-                val length = repo.setsForMusclesInWeek(Instant.now()).setCounts.size
+                val length = setCounts.size
                 assertEquals(2, length)
                 assertEquals(1, setCounts[muscleA.id]?.thisWeek)
                 assertEquals(0, setCounts[muscleB.id]?.thisWeek)
+            }
+        }
+    }
+
+    @Test
+    fun setForMusclesInWeek_set_in_prev_week() {
+
+        runBlocking() {
+            launch {
+                repo.dropDb()
+
+                val muscleA = repo.newMuscle()
+                val exerciseA = repo.newExercise(muscleA.id)
+
+                val location = repo.newLocation()
+                val equipment = repo.newEquipment(location.id)
+                val now = OffsetDateTime.now()
+                repo.newWorkoutSet(
+                    location.id,
+                    equipment.id,
+                    exerciseA.id,
+                    now.minusWeeks(1).toInstant()
+                )
+
+                val muscles = repo.getMuscles()
+
+                assertEquals(1, muscles.size)
+
+                val setCounts = repo.setsForMusclesInWeek(Instant.now()).setCounts
+                assertEquals(1, setCounts.size)
             }
         }
     }

--- a/app/src/main/java/org/wspcgir/strong_giraffe/repository/AppRepository.kt
+++ b/app/src/main/java/org/wspcgir/strong_giraffe/repository/AppRepository.kt
@@ -84,11 +84,11 @@ class AppRepository(private val dao: AppDao) {
     suspend fun newWorkoutSet(
         location: LocationId,
         equipment: EquipmentId,
-        exercise: ExerciseId
+        exercise: ExerciseId,
+        time: Instant = Instant.now(),
     ): WorkoutSet {
         val id = UUID.randomUUID().toString()
         val reps = 10
-        val time = Instant.now()
         val comment = ""
         val weight = 0
         dao.insertWorkoutSet(


### PR DESCRIPTION
# Summary

Fixes: https://github.com/JD95/strong-giraffe/issues/34

The old query only accounted for two situations
- The muscle has no pre-existing sets at all
- The muscle has quality sets in the current week

This means that muscles with sets in previous weeks, but not this one, would not return from the query. The new one guarantees that all muscles are at least included with a 0 