### PR TITLE
[Feature] Sets jumped to from the set entry page will now be locked by default

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "org.wspcgir.strong_giraffe"
         minSdk 33
         targetSdk 34
-        versionCode 13
-        versionName "0.7.0"
+        versionCode 14
+        versionName "0.8.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/org/wspcgir/strong_giraffe/destinations/EditMusclePage.kt
+++ b/app/src/main/java/org/wspcgir/strong_giraffe/destinations/EditMusclePage.kt
@@ -28,6 +28,7 @@ abstract class EditMusclePageViewModel : ViewModel() {
 
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @Destination(navArgsDelegate = EditMusclePageNavArgs::class)
 fun EditMusclePage(view: EditMusclePageViewModel) {

--- a/app/src/main/java/org/wspcgir/strong_giraffe/destinations/EditSetPage.kt
+++ b/app/src/main/java/org/wspcgir/strong_giraffe/destinations/EditSetPage.kt
@@ -339,7 +339,7 @@ fun Page(
                 val zone = TimeZone.getDefault().toZoneId()
                 val date = OffsetDateTime.ofInstant(starting.value.time, zone)
                 val dateFormat = DateTimeFormatter.ofPattern("MMMM dd, yyyy")
-                val timeFormat = DateTimeFormatter.ofPattern("HH:MM:SS")
+                val timeFormat = DateTimeFormatter.ofPattern("HH:MM:ss")
                 Text(date.format(dateFormat), fontSize = FIELD_NAME_FONT_SIZE)
                 Text(date.format(timeFormat), fontSize = FIELD_NAME_FONT_SIZE)
                 Card() {

--- a/app/src/main/java/org/wspcgir/strong_giraffe/destinations/EditSetPage.kt
+++ b/app/src/main/java/org/wspcgir/strong_giraffe/destinations/EditSetPage.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Warning
@@ -42,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
@@ -79,7 +81,7 @@ import java.util.TimeZone
 
 data class EditSetPageNavArgs(val id: SetId, val locked: Boolean)
 
-val NUM_PREVIOUS_SETS = 6
+const val NUM_PREVIOUS_SETS = 6
 
 class EditSetPageViewModel(
     private val setId: SetId,
@@ -171,7 +173,7 @@ class EditSetPageViewModel(
     }
 
     fun toggleSetLock(new: Boolean) {
-       lockedMut.value = new
+        lockedMut.value = new
     }
 
     val locked: State<Boolean>
@@ -286,7 +288,11 @@ fun Page(
         val validWeight = remember { mutableStateOf(true) }
 
         ModalDrawerScaffold(
-            title = "Edit Set",
+            title = if (locked) {
+                "View Set"
+            } else {
+                "Edit Set"
+            },
             drawerContent = {
                 Column(
                     modifier = Modifier.fillMaxSize(),
@@ -319,7 +325,9 @@ fun Page(
             },
             actionButton = {
                 FloatingActionButton(onClick = submit) {
-                    if (validReps.value && validWeight.value) {
+                    if (locked) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Set Locked")
+                    } else if (validReps.value && validWeight.value) {
                         Icon(Icons.Default.Done, contentDescription = "Save Set")
                     } else {
                         Icon(Icons.Default.Warning, contentDescription = "Invalid fields")
@@ -342,7 +350,7 @@ fun Page(
                 val timeFormat = DateTimeFormatter.ofPattern("HH:MM:ss")
                 Text(date.format(dateFormat), fontSize = FIELD_NAME_FONT_SIZE)
                 Text(date.format(timeFormat), fontSize = FIELD_NAME_FONT_SIZE)
-                Card() {
+                Card {
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -381,7 +389,7 @@ fun Page(
                         )
                     }
                 }
-                Card() {
+                Card {
                     RepsAndWeightSelector(
                         starting,
                         validReps,
@@ -391,10 +399,10 @@ fun Page(
                         changeWeight,
                     )
                 }
-                Card() {
+                Card {
                     IntensitySelector(changeIntensity, starting, enabled = !locked)
                 }
-                Card() {
+                Card {
                     Column(
                         modifier = Modifier.padding(10.dp)
                     ) {
@@ -410,7 +418,7 @@ fun Page(
                     }
                 }
                 LazyRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    this.item() { Spacer(modifier = Modifier.width(25.dp)) }
+                    this.item { Spacer(modifier = Modifier.width(25.dp)) }
                     this.items(previousSets.value) { set ->
                         PreviousSetButton(set.reps, set.weight, set.intensity) { gotoSet(set) }
                     }
@@ -432,7 +440,13 @@ private fun IntensitySelector(
             Intensity.toInt(starting.value.intensity).toFloat()
         )
     }
-    Column {
+    val columnModifier =
+        if (enabled) {
+            Modifier
+        } else {
+            Modifier.alpha(0.45f)
+        }
+    Column(modifier = columnModifier) {
         Spacer(modifier = Modifier.height(10.dp))
         Row {
             Spacer(modifier = Modifier.width(10.dp))
@@ -484,7 +498,7 @@ private fun RepsAndWeightSelector(
                     label = "Reps",
                     enabled = enabled,
                     start = starting.value.reps.value,
-                ) { it ->
+                ) {
                     validReps.value = it != null
                     if (it != null) {
                         changeReps(Reps(it))
@@ -498,7 +512,7 @@ private fun RepsAndWeightSelector(
                 IntField(
                     label = "Weight",
                     start = starting.value.weight.value,
-                    onChange = { it ->
+                    onChange = {
                         validWeight.value = it != null
                         if (it != null) {
                             changeWeight(Weight(it))

--- a/app/src/main/java/org/wspcgir/strong_giraffe/destinations/SetListPage.kt
+++ b/app/src/main/java/org/wspcgir/strong_giraffe/destinations/SetListPage.kt
@@ -105,7 +105,7 @@ fun RegisterSetListPage(repo: AppRepository, dest: DestinationsNavigator) {
                     }
                     dest.navigate(
                         EditSetPageDestination(
-                            EditSetPageNavArgs(id = set.id)
+                            EditSetPageNavArgs(id = set.id, false)
                         )
                     )
                 }
@@ -113,7 +113,7 @@ fun RegisterSetListPage(repo: AppRepository, dest: DestinationsNavigator) {
 
             override fun goto(id: SetSummary) {
                 viewModelScope.launch {
-                    dest.navigate(EditSetPageDestination(EditSetPageNavArgs(id = id.id)))
+                    dest.navigate(EditSetPageDestination(EditSetPageNavArgs(id = id.id, false)))
                 }
             }
         })

--- a/app/src/main/java/org/wspcgir/strong_giraffe/views/LargeDropDownFromList.kt
+++ b/app/src/main/java/org/wspcgir/strong_giraffe/views/LargeDropDownFromList.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 fun <T> LargeDropDownFromList(
     items: List<T>,
     label: String,
+    enabled: Boolean = true,
     selectedIndex: Int,
     itemToString: (T) -> String,
     onItemSelected: (T) -> Unit,
@@ -14,6 +15,7 @@ fun <T> LargeDropDownFromList(
 ) {
     LargeDropDownMenu(
         modifier = modifier,
+        enabled = enabled,
         label = label,
         items = items,
         onItemSelected = { _, x -> onItemSelected(x) },

--- a/app/src/main/java/org/wspcgir/strong_giraffe/views/ModalDrawerScaffold.kt
+++ b/app/src/main/java/org/wspcgir/strong_giraffe/views/ModalDrawerScaffold.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.BottomAppBar
-import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -23,11 +22,12 @@ import kotlinx.coroutines.launch
 @Composable
 fun ModalDrawerScaffold(
     title: String,
+    initialDrawerValue: DrawerValue = DrawerValue.Closed,
     drawerContent: @Composable ColumnScope.() -> Unit,
     actionButton: @Composable () -> Unit,
     content: @Composable (PaddingValues) -> Unit,
 ) {
-    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+    val drawerState = rememberDrawerState(initialValue = initialDrawerValue)
     val scope = rememberCoroutineScope()
     ModalNavigationDrawer(
         drawerState = drawerState,

--- a/app/src/main/java/org/wspcgir/strong_giraffe/views/ValueField.kt
+++ b/app/src/main/java/org/wspcgir/strong_giraffe/views/ValueField.kt
@@ -17,11 +17,13 @@ import androidx.compose.ui.text.input.KeyboardType
 fun IntField(
     label: String,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     start: Int = 0,
-    onChange: (Int?) -> Unit
+    onChange: (Int?) -> Unit,
 ) {
     ValueField(
         label = label,
+        enabled = enabled,
         modifier = modifier,
         start = start,
         fromString = String::toIntOrNull,
@@ -33,11 +35,13 @@ fun IntField(
 fun FloatField(
     label: String,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     start: Float = 0f,
     onChange: (Float?) -> Unit
 ) {
     ValueField(
         label = label,
+        enabled = enabled,
         modifier = modifier,
         start = start,
         fromString = String::toFloatOrNull,
@@ -50,6 +54,7 @@ fun FloatField(
 fun <T> ValueField(
     label: String,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     singleLine: Boolean = true,
     start: T,
     fromString: (String) -> T?,
@@ -70,6 +75,7 @@ fun <T> ValueField(
     TextField(
         value = text,
         modifier = modifier,
+        enabled = enabled,
         label = { Text(label) },
         keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
         keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),


### PR DESCRIPTION
# Summary

It was confusing for users when navigating to older sets via the set entry page since it was easy to accidentally do so and not realize it. This prevents accidentally altering older set data and should provide enough visual difference.